### PR TITLE
reverted and added index for cleaner import and capitalised classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Open your Angular2+ application and install the package from NPM
 Add the following to the app.module.ts file in your application.
 
 ```javascript
-import { ngGridifyModule } from './../../node_modules/nggridify2/ng-gridify.module';
+import { NgGridifyModule } from 'ng-gridify';
 ```
 
 Import it into the application.
@@ -32,14 +32,14 @@ Import it into the application.
 ```javascript
     imports: [
         [/*Other Imports*/]
-        ngGridifyModule
+        NgGridifyModule
     ]
 ```   
 
 Add the following in the component that uses it for the data type that is required to bind.
 
 ```javascript
-import { ngGridifyData } from './../../node_modules/nggridify2/ng-gridify.types';
+import { ngGridifyData } from 'ng-gridify';
 ```
 
 Declare the component in the markup and choose what data to pass in.

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,3 @@
+export { NgGridifyModule } from './ng-gridify.module';
+export { NgGridifyComponent } from './ng-gridify.component';
+export { ngGridifyData, ngGridifyColumn } from './ng-gridify.types';

--- a/ng-gridify.component.ts
+++ b/ng-gridify.component.ts
@@ -34,7 +34,7 @@ import { ngGridifyData } from './ng-gridify.types';
     </table>
   `
 })
-export class ngGridifyComponent {
+export class NgGridifyComponent {
 
   // Columns: [
   //   { Name: 'Id', DisplayValue: 'Id', Width: '200' },

--- a/ng-gridify.module.ts
+++ b/ng-gridify.module.ts
@@ -1,13 +1,11 @@
 import { NgModule } from '@angular/core';
-import { ngGridifyComponent } from './ng-gridify.component';
+import { NgGridifyComponent } from './ng-gridify.component';
 import { CommonModule } from '@angular/common';
 import { PagePipe } from './ng-gridify.page.pipe'
 
 @NgModule({
-    declarations: [ngGridifyComponent, PagePipe],
-    exports: [ngGridifyComponent],
+    declarations: [NgGridifyComponent, PagePipe],
+    exports: [NgGridifyComponent],
     imports: [CommonModule] // Used for ngFor
 })
-export class ngGridifyModule {}
-
-export { ngGridifyComponent };
+export class NgGridifyModule {}


### PR DESCRIPTION
Breaking changes as classes are now capitalised, I added an index file so you can now do:
`import { NgGridifyModule } from 'nggridify2';`